### PR TITLE
Show errors from OpenAI

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -122,7 +122,12 @@ export default class CommandHandler {
         return;
       }
 
-      const result = await sendChatGPTMessage(this.chatGPT, await bodyWithoutPrefix, storedConversation);
+      const result = await sendChatGPTMessage(this.chatGPT, await bodyWithoutPrefix, storedConversation)
+        .catch((error) => {
+          LogService.warn(`OpenAPI Error: ${error}`);
+          sendError(this.client, "Sorry, there was an error using the OpenAI-API. Details: " + error, roomId, event.event_id);
+          return;
+      });
       await Promise.all([
         this.client.setTyping(roomId, false, 500),
         sendReply(this.client, roomId, this.getRootEventId(event), `${result.response}`, MATRIX_THREADS, MATRIX_RICH_TEXT)

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -124,9 +124,8 @@ export default class CommandHandler {
 
       const result = await sendChatGPTMessage(this.chatGPT, await bodyWithoutPrefix, storedConversation)
         .catch((error) => {
-          LogService.warn(`OpenAI-API Error: ${error}`);
-          sendError(this.client, `Sorry, there was an error using the OpenAI-API. Details:\n${error}`, roomId, event.event_id);
-          return;
+          LogService.error(`OpenAI-API Error: ${error}`);
+          sendError(this.client, "The bot has encountered an error, please contact your administrator.", roomId, event.event_id);
       });
       await Promise.all([
         this.client.setTyping(roomId, false, 500),

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -124,7 +124,7 @@ export default class CommandHandler {
 
       const result = await sendChatGPTMessage(this.chatGPT, await bodyWithoutPrefix, storedConversation)
         .catch((error) => {
-          LogService.warn(`OpenAPI Error: ${error}`);
+          LogService.warn(`OpenAI-API Error: ${error}`);
           sendError(this.client, `Sorry, there was an error using the OpenAI-API. Details:\n${error}`, roomId, event.event_id);
           return;
       });

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -125,7 +125,7 @@ export default class CommandHandler {
       const result = await sendChatGPTMessage(this.chatGPT, await bodyWithoutPrefix, storedConversation)
         .catch((error) => {
           LogService.warn(`OpenAPI Error: ${error}`);
-          sendError(this.client, "Sorry, there was an error using the OpenAI-API. Details: " + error, roomId, event.event_id);
+          sendError(this.client, `Sorry, there was an error using the OpenAI-API. Details:\n${error}`, roomId, event.event_id);
           return;
       });
       await Promise.all([


### PR DESCRIPTION
As the model currently is overloaded (or taken down by OpenAI, who knows :/) I thought this is the perfect moment for us to improve the error handling.

I didn't parse the error thrown by the API nor did I format the text to some sort of rich text. I've just passed it directly to the user. Not sure how I feel about this.

Currently it looks like this:
![grafik](https://user-images.githubusercontent.com/61061388/217501759-97a8da3f-0fcf-48a4-be80-5afbe8903b17.png)

