### PR TITLE
set default to official ChatGPT model from OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,9 @@ OPENAI_API_KEY=
 
 # Set the ChatGPT conversation context to 'thread', 'room' or 'both'.
 CHATGPT_CONTEXT=thread
-# (Optional) Explicitly set the ChatGPT model to be used by the API.
-#CHATGPT_API_MODEL=gpt-3.5-turbo
+# Set the ChatGPT model to be used by the API. 'gpt-3.5-turbo' is the official ChatGPT-model from OpenAI
+# Note that the models are not free and will charge your OpenAI account depending on the usage of tokens
+CHATGPT_API_MODEL=gpt-3.5-turbo
 # (Optional) Explicitly set the prefix sent to model at the beginning of a conversation
 #CHATGPT_PROMPT_PREFIX=Instructions:\nYou are ChatGPT, a large language model trained by OpenAI.
 # (Optional) Set to true if ChatGPT should ignore any messages which are not text

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ OPENAI_API_KEY=
 # Set the ChatGPT conversation context to 'thread', 'room' or 'both'.
 CHATGPT_CONTEXT=thread
 # (Optional) Explicitly set the ChatGPT model to be used by the API.
-#CHATGPT_MODEL=text-chat-davinci-002-20221122
+#CHATGPT_MODEL=gpt-3.5-turbo
 # (Optional) Explicitly set the prefix sent to model at the beginning of a conversation
 #CHATGPT_PROMPT_PREFIX=Instructions:\nYou are ChatGPT, a large language model trained by OpenAI.
 # (Optional) Set to true if ChatGPT should ignore any messages which are not text

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ OPENAI_API_KEY=
 # Set the ChatGPT conversation context to 'thread', 'room' or 'both'.
 CHATGPT_CONTEXT=thread
 # (Optional) Explicitly set the ChatGPT model to be used by the API.
-#CHATGPT_MODEL=gpt-3.5-turbo
+#CHATGPT_API_MODEL=gpt-3.5-turbo
 # (Optional) Explicitly set the prefix sent to model at the beginning of a conversation
 #CHATGPT_PROMPT_PREFIX=Instructions:\nYou are ChatGPT, a large language model trained by OpenAI.
 # (Optional) Set to true if ChatGPT should ignore any messages which are not text

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Talk to ChatGPT via any Matrix client!
 A Matrix bot that uses [waylaidwanderer/node-chatgpt-api](https://github.com/waylaidwanderer/node-chatgpt-api) to access the unofficial ChatGPT API.
 
 ## Warning for users upgrading from version 2.x
-OpenAI released the [official API for ChatGPT](https://openai.com/blog/introducing-chatgpt-and-whisper-apis). Thus, we no longer have to use any older models or any models which kept on being turned off by OpenAI. This means the bot is now way more stable and way faster. However, please note: The usage of the API is **no longer free**. If you use this bot, your OpenAI account **will be charged**! You might want to limit your budget in your account using the OpenAI website.
+OpenAI released the [official API for ChatGPT](https://openai.com/blog/introducing-chatgpt-and-whisper-apis). Thus, we no longer have to use any older models or any models which kept on being turned off by OpenAI. This means the bot is now way more stable and way faster. However, please note: The usage of the API is **no longer free**. If you use this bot, your OpenAI account **will be charged**! You might want to limit your budget in your account using the [OpenAI website](https://platform.openai.com/account/billing).
+You need to remove the `CHATGPT_MODEL` variable from your environment, if you changed the value.
 
 # Usage
 1. Create a room

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Talk to ChatGPT via any Matrix client!
 
 ![Screenshot of Element iOS app showing conversation with bot](img/matrix-chatgpt.png)
 
-A Matrix bot that uses [waylaidwanderer/node-chatgpt-api](https://github.com/waylaidwanderer/node-chatgpt-api) to access the unofficial ChatGPT API.
+A Matrix bot that uses [waylaidwanderer/node-chatgpt-api](https://github.com/waylaidwanderer/node-chatgpt-api) to access the official ChatGPT API.
 
 ## Warning for users upgrading from version 2.x
 OpenAI released the [official API for ChatGPT](https://openai.com/blog/introducing-chatgpt-and-whisper-apis). Thus, we no longer have to use any older models or any models which kept on being turned off by OpenAI. This means the bot is now way more stable and way faster. However, please note: The usage of the API is **no longer free**. If you use this bot, your OpenAI account **will be charged**! You might want to limit your budget in your account using the [OpenAI website](https://platform.openai.com/account/billing).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Talk to ChatGPT via any Matrix client!
 
 A Matrix bot that uses [waylaidwanderer/node-chatgpt-api](https://github.com/waylaidwanderer/node-chatgpt-api) to access the unofficial ChatGPT API.
 
+## Warning for users upgrading from version 2.x
+OpenAI released the [official API for ChatGPT](https://openai.com/blog/introducing-chatgpt-and-whisper-apis). Thus, we no longer have to use any older models or any models which kept on being turned off by OpenAI. This means the bot is now way more stable and way faster. However, please note: The usage of the API is **no longer free**. If you use this bot, your OpenAI account **will be charged**! You might want to limit your budget in your account using the OpenAI website.
+
 # Usage
 1. Create a room
 2. Add the bot
@@ -39,7 +42,7 @@ Adjust all required settings in the `.env` file before running. Optional setting
 ### OpenAI / ChatGPT
 - You need to have an account at [openai.com](https://openai.com/). Please note that the usage of the ChatGPT-API is not free.
 - Create a [API Key](https://platform.openai.com/account/api-keys). Then, set `OPENAI_API_KEY` in your `.env` file
-- You might want to change to chat-model by setting the `CHATGPT_MODEL` in your `.env` file. ChatGPT is the `gpt-3.5-turbo`-model which is the default. Please note that depending on the model, your OpenAI account will be charged.
+- You can change the chat-model by setting the `CHATGPT_API_MODEL` in your `.env` file. ChatGPT is the `gpt-3.5-turbo`-model which is the default. Please note that depending on the model your OpenAI account will be charged.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@ Talk to ChatGPT via any Matrix client!
 
 A Matrix bot that uses [waylaidwanderer/node-chatgpt-api](https://github.com/waylaidwanderer/node-chatgpt-api) to access the unofficial ChatGPT API.
 
-## ⚠️ Currently there is no free ChatGPT model provided by the OpenAI-API ⚠️
-
-The bot <ins>won't work</ins> as expected out of the box and there is no known free model which can be used:
-
-- The `CHATGPT_MODEL` environment can be used to set the model - as of writing the default uses a model of ChatGPT from late 2022 which is **not working at the moment** and we do not know if and when this will change. However, you can change the `CHATGPT_MODEL` env to `text-davinci-003` or any other of the [supported models](https://platform.openai.com/docs/models/gpt-3). Keep in mind that that these alternative models are not free and will cost you OpenAI credits.
-- Check the [waylaidwanderer/node-chatgpt-api](https://github.com/waylaidwanderer/node-chatgpt-api) repository for any updates on this.
-
 # Usage
 1. Create a room
 2. Add the bot
@@ -44,11 +37,9 @@ Adjust all required settings in the `.env` file before running. Optional setting
 - When using a self-hosted setup, you could wildcard all your users with `MATRIX_WHITELIST=:yourhomeserver.example`.
 
 ### OpenAI / ChatGPT
-- You need to have an account at [openai.com](https://openai.com/).
+- You need to have an account at [openai.com](https://openai.com/). Please note that the usage of the ChatGPT-API is not free.
 - Create a [API Key](https://platform.openai.com/account/api-keys). Then, set `OPENAI_API_KEY` in your `.env` file
-- You might want to change to chat-model by setting the `CHATGPT_MODEL` in your `.env` file.
-- The model currently defaults to `text-chat-davinci-002-20221122`.
-- Check the [node-chatgpt-api](https://github.com/waylaidwanderer/node-chatgpt-api) repository to keep track of the models.
+- You might want to change to chat-model by setting the `CHATGPT_MODEL` in your `.env` file. ChatGPT is the `gpt-3.5-turbo`-model which is the default. Please note that depending on the model, your OpenAI account will be charged.
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@keyv/postgres": "^1.4.1",
     "@keyv/redis": "^2.5.4",
     "@keyv/sqlite": "^3.6.4",
-    "@waylaidwanderer/chatgpt-api": "^1.22.0",
+    "@waylaidwanderer/chatgpt-api": "^1.23.0",
     "dotenv": "^16.0.3",
     "hash.js": "^1.1.7",
     "keyv": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@keyv/postgres": "^1.4.1",
     "@keyv/redis": "^2.5.4",
     "@keyv/sqlite": "^3.6.4",
-    "@waylaidwanderer/chatgpt-api": "^1.23.0",
+    "@waylaidwanderer/chatgpt-api": "^1.26.0",
     "dotenv": "^16.0.3",
     "hash.js": "^1.1.7",
     "keyv": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@keyv/postgres": "^1.4.1",
     "@keyv/redis": "^2.5.4",
     "@keyv/sqlite": "^3.6.4",
-    "@waylaidwanderer/chatgpt-api": "^1.10.5",
+    "@waylaidwanderer/chatgpt-api": "^1.22.0",
     "dotenv": "^16.0.3",
     "hash.js": "^1.1.7",
     "keyv": "^4.5.2",

--- a/src/env.ts
+++ b/src/env.ts
@@ -64,7 +64,7 @@ export const {
   OPENAI_API_KEY:              { schema: z.string().default(""),                   description: "Set to the API key from https://platform.openai.com/account/api-keys"},
   CHATGPT_TIMEOUT:             { schema: z.number().default(2 * 60 * 1000),        description: "Set number of milliseconds to wait for ChatGPT responses" },
   CHATGPT_CONTEXT:             { schema: z.enum(["thread", "room", "both"]).default("thread"), description: "Set the ChatGPT conversation context to 'thread', 'room' or 'both'" },
-  CHATGPT_API_MODEL:               { schema: z.string().default("gpt-3.5-turbo"), description: "The model for the ChatGPT-API to use. Keep in mind that these models will charge your OpenAI account depending on their pricing." },
+  CHATGPT_API_MODEL:           { schema: z.string().default(""),                   description: "The model for the ChatGPT-API to use. Keep in mind that these models will charge your OpenAI account depending on their pricing." },
   CHATGPT_PROMPT_PREFIX:       { schema: z.string().default('Instructions:\nYou are ChatGPT, a large language model trained by OpenAI.'), description: "Instructions to feed to ChatGPT on startup"},
   CHATGPT_IGNORE_MEDIA:        { schema: z.boolean().default(false),               description: "Wether or not the bot should react to non-text messages"},
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -32,7 +32,7 @@ export const {
   OPENAI_API_KEY,
   CHATGPT_CONTEXT,
   CHATGPT_TIMEOUT,
-  CHATGPT_MODEL,
+  CHATGPT_API_MODEL,
   CHATGPT_PROMPT_PREFIX,
   CHATGPT_IGNORE_MEDIA,
 } = parseEnv(process.env, {
@@ -64,7 +64,7 @@ export const {
   OPENAI_API_KEY:              { schema: z.string().default(""),                   description: "Set to the API key from https://platform.openai.com/account/api-keys"},
   CHATGPT_TIMEOUT:             { schema: z.number().default(2 * 60 * 1000),        description: "Set number of milliseconds to wait for ChatGPT responses" },
   CHATGPT_CONTEXT:             { schema: z.enum(["thread", "room", "both"]).default("thread"), description: "Set the ChatGPT conversation context to 'thread', 'room' or 'both'" },
-  CHATGPT_MODEL:               { schema: z.string().default("gpt-3.5-turbo"), description: "The model for the ChatGPT-API to use" },
+  CHATGPT_API_MODEL:               { schema: z.string().default("gpt-3.5-turbo"), description: "The model for the ChatGPT-API to use. Keep in mind that these models will charge your OpenAI account depending on their pricing." },
   CHATGPT_PROMPT_PREFIX:       { schema: z.string().default('Instructions:\nYou are ChatGPT, a large language model trained by OpenAI.'), description: "Instructions to feed to ChatGPT on startup"},
   CHATGPT_IGNORE_MEDIA:        { schema: z.boolean().default(false),               description: "Wether or not the bot should react to non-text messages"},
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -64,7 +64,7 @@ export const {
   OPENAI_API_KEY:              { schema: z.string().default(""),                   description: "Set to the API key from https://platform.openai.com/account/api-keys"},
   CHATGPT_TIMEOUT:             { schema: z.number().default(2 * 60 * 1000),        description: "Set number of milliseconds to wait for ChatGPT responses" },
   CHATGPT_CONTEXT:             { schema: z.enum(["thread", "room", "both"]).default("thread"), description: "Set the ChatGPT conversation context to 'thread', 'room' or 'both'" },
-  CHATGPT_MODEL:               { schema: z.string().default("text-chat-davinci-002-20221122"), description: "The model for the ChatGPT-API to use" },
+  CHATGPT_MODEL:               { schema: z.string().default("gpt-3.5-turbo"), description: "The model for the ChatGPT-API to use" },
   CHATGPT_PROMPT_PREFIX:       { schema: z.string().default('Instructions:\nYou are ChatGPT, a large language model trained by OpenAI.'), description: "Instructions to feed to ChatGPT on startup"},
   CHATGPT_IGNORE_MEDIA:        { schema: z.boolean().default(false),               description: "Wether or not the bot should react to non-text messages"},
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,13 @@ async function main() {
   if (!MATRIX_THREADS && CHATGPT_CONTEXT !== "room") throw Error("You must set CHATGPT_CONTEXT to 'room' if you set MATRIX_THREADS to false")
   const client: MatrixClient = new MatrixClient(MATRIX_HOMESERVER_URL, MATRIX_ACCESS_TOKEN, storage, cryptoStore);
 
+  if (!CHATGPT_API_MODEL) {
+    LogService.warn("index", "This bot now uses the official API from ChatGPT. In order to migrate add the CHATGPT_API_MODEL variable to your .env");
+    LogService.warn("index", "The official ChatGPT-model which should be used is 'gpt-3.5-turbo'. See the .env.example for details")
+    LogService.warn("index", "Please note that the usage of the models charge your OpenAI account and are not free to use");
+    return;
+  }
+
   const clientOptions = {  // (Optional) Parameters as described in https://platform.openai.com/docs/api-reference/completions
     modelOptions: {
       model: CHATGPT_API_MODEL,  // The model is set to gpt-3.5-turbo by default
@@ -52,6 +59,7 @@ async function main() {
     promptPrefix: wrapPrompt(CHATGPT_PROMPT_PREFIX),
     debug: false,
   };
+
   const chatgpt = new ChatGPTClient(OPENAI_API_KEY, clientOptions, cacheOptions);
 
   // Automatically join rooms the bot is invited to

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ async function main() {
 
   const clientOptions = {  // (Optional) Parameters as described in https://platform.openai.com/docs/api-reference/completions
     modelOptions: {
-      model: CHATGPT_MODEL,  // The model is set to text-chat-davinci-002-20221122 by default
+      model: CHATGPT_MODEL,  // The model is set to gpt-3.5-turbo by default
     },
     promptPrefix: wrapPrompt(CHATGPT_PROMPT_PREFIX),
     debug: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from "matrix-bot-sdk";
 
 import * as path from "path";
-import { DATA_PATH, KEYV_URL, OPENAI_API_KEY, MATRIX_HOMESERVER_URL, MATRIX_ACCESS_TOKEN, MATRIX_AUTOJOIN, MATRIX_BOT_PASSWORD, MATRIX_BOT_USERNAME, MATRIX_ENCRYPTION, MATRIX_THREADS, CHATGPT_CONTEXT, CHATGPT_MODEL, KEYV_BOT_STORAGE, KEYV_BACKEND, CHATGPT_PROMPT_PREFIX, MATRIX_WELCOME } from './env.js'
+import { DATA_PATH, KEYV_URL, OPENAI_API_KEY, MATRIX_HOMESERVER_URL, MATRIX_ACCESS_TOKEN, MATRIX_AUTOJOIN, MATRIX_BOT_PASSWORD, MATRIX_BOT_USERNAME, MATRIX_ENCRYPTION, MATRIX_THREADS, CHATGPT_CONTEXT, CHATGPT_API_MODEL, KEYV_BOT_STORAGE, KEYV_BACKEND, CHATGPT_PROMPT_PREFIX, MATRIX_WELCOME } from './env.js'
 import CommandHandler from "./handlers.js"
 import { KeyvStorageProvider } from './storage.js'
 import { parseMatrixUsernamePretty, wrapPrompt } from './utils.js';
@@ -47,7 +47,7 @@ async function main() {
 
   const clientOptions = {  // (Optional) Parameters as described in https://platform.openai.com/docs/api-reference/completions
     modelOptions: {
-      model: CHATGPT_MODEL,  // The model is set to gpt-3.5-turbo by default
+      model: CHATGPT_API_MODEL,  // The model is set to gpt-3.5-turbo by default
     },
     promptPrefix: wrapPrompt(CHATGPT_PROMPT_PREFIX),
     debug: false,
@@ -77,7 +77,7 @@ async function main() {
   const commands = new CommandHandler(client, chatgpt);
   await commands.start();
 
-  LogService.info("index", `Starting bot using ChatGPT model: ${CHATGPT_MODEL}`);
+  LogService.info("index", `Starting bot using ChatGPT model: ${CHATGPT_API_MODEL}`);
   LogService.info("index", `Using promptPrefix: ${wrapPrompt(CHATGPT_PROMPT_PREFIX)}`)
   await client.start()
   LogService.info("index", "Bot started!");

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,10 +942,10 @@
     "@types/node" "*"
     "@types/webidl-conversions" "*"
 
-"@waylaidwanderer/chatgpt-api@^1.23.0":
-  version "1.23.2"
-  resolved "https://registry.yarnpkg.com/@waylaidwanderer/chatgpt-api/-/chatgpt-api-1.23.2.tgz#6cd8051d39fdb5a1d11aa8f2cb6a2cd6de31c49c"
-  integrity sha512-JBXwqASFBazp1W7qQKZ0tV88WQ4/xqCX6B4g+XJqMM1QbHSFJ9uEnTbZrUUFFCnOzsmHwDg/UMizl2ISB4dAsw==
+"@waylaidwanderer/chatgpt-api@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@waylaidwanderer/chatgpt-api/-/chatgpt-api-1.26.0.tgz#85d0f70af34350e0ebebac827fad7446adcdf1af"
+  integrity sha512-0hde3Uz02nklhSBp16hNfPtWiW3saFBqeI7PHPVtoU+7oFOHyB4747ewxIJwCYHzTo0aUZEDQHK3kAToPsKU9A==
   dependencies:
     "@dqbd/tiktoken" "^0.4.0"
     "@fastify/cors" "^8.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,25 +937,36 @@
     "@types/node" "*"
     "@types/webidl-conversions" "*"
 
-"@waylaidwanderer/chatgpt-api@^1.10.5":
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/@waylaidwanderer/chatgpt-api/-/chatgpt-api-1.10.5.tgz#8683cbf6f7c495e1e757832c7a718c99c518201d"
-  integrity sha512-aLECPQN/zLorDXldN1ApHqoE4KPp+I3GmW9RtExmzgR0TaFWb2f2GQMbuTKrZWDsadOo3wUO8AssTR1Zc7nkrg==
+"@waylaidwanderer/chatgpt-api@^1.22.0":
+  version "1.22.5"
+  resolved "https://registry.yarnpkg.com/@waylaidwanderer/chatgpt-api/-/chatgpt-api-1.22.5.tgz#8613c0cd84c1fc4784b49b90dde560ea44231701"
+  integrity sha512-mjuui0ZuBYqpAbpKtpbrP3iYpNBHL5Uj2Rq42jYXBXC5mVTH6GPIUxczrWLFucHYTxau0kupa9SOoeBOZ4d+JQ==
   dependencies:
     "@fastify/cors" "^8.2.0"
+    "@waylaidwanderer/fastify-sse-v2" "^3.1.0"
     "@waylaidwanderer/fetch-event-source" "^3.0.1"
     boxen "^7.0.1"
     clipboardy "^3.0.0"
     dotenv "^16.0.3"
     fastify "^4.11.0"
-    fastify-sse-v2 "^3.0.0"
+    fetch-undici "^3.0.1"
     gpt-3-encoder "^1.1.4"
+    https-proxy-agent "^5.0.1"
     inquirer "^9.1.4"
     inquirer-autocomplete-prompt "^3.0.0"
     keyv "^4.5.2"
     keyv-file "^0.2.0"
-    node-fetch "^3.3.0"
     ora "^6.1.2"
+    ws "^8.12.0"
+
+"@waylaidwanderer/fastify-sse-v2@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@waylaidwanderer/fastify-sse-v2/-/fastify-sse-v2-3.1.0.tgz#cf9bb180897a1681d9d39328f94e48c4b24a4b8e"
+  integrity sha512-R6/VT14+iGZmyp7Jih7FYZuWr0B0gJ9uym1xoVPlKjZBngzFS2bL8yvZyEIPbMrTjrC8syZY2z2WuMHsipRfpw==
+  dependencies:
+    fastify-plugin "^4.3.0"
+    it-pushable "^1.4.2"
+    it-to-stream "^1.0.0"
 
 "@waylaidwanderer/fetch-event-source@^3.0.1":
   version "3.0.1"
@@ -1277,6 +1288,13 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -1479,11 +1497,6 @@ dashdash@^1.12.0:
   integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
   dependencies:
     assert-plus "^1.0.0"
-
-data-uri-to-buffer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
-  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
 debug@2.6.9:
   version "2.6.9"
@@ -1848,15 +1861,6 @@ fastify-plugin@^4.0.0, fastify-plugin@^4.3.0:
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-4.5.0.tgz#8b853923a0bba6ab6921bb8f35b81224e6988d91"
   integrity sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg==
 
-fastify-sse-v2@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fastify-sse-v2/-/fastify-sse-v2-3.0.0.tgz#b4b7dbd87d6b9629de820af2415d9af92c506b6f"
-  integrity sha512-UJF1BtyNOlLhOvlqMS/mBupmM8JOpJ3UmoFeNuKYdBClH+euJrO1mV2L0vfIpFKut9iy6tT23/JmN46QWCtBAg==
-  dependencies:
-    fastify-plugin "^4.3.0"
-    it-pushable "^1.4.2"
-    it-to-stream "^1.0.0"
-
 fastify@^4.11.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/fastify/-/fastify-4.12.0.tgz#e5330215d95702336693b38b2e66d34ee8300d3e"
@@ -1885,13 +1889,12 @@ fastq@^1.6.1:
   dependencies:
     reusify "^1.0.4"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+fetch-undici@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fetch-undici/-/fetch-undici-3.0.1.tgz#d7ea6b478f99489cc6e51a29c21e8b26304eb1c4"
+  integrity sha512-UHHu1HqW22ZhK6C/1Zmjf7mQpOwPwLYZ+xcsOgpzistONU8QqvCop6Od29p/kw1GUVoq2Ihu6ItpKLtlojx4FQ==
   dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
+    undici "^5.0.0"
 
 figures@^5.0.0:
   version "5.0.0"
@@ -1936,13 +1939,6 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2181,7 +2177,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^5.0.0:
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -2795,11 +2791,6 @@ node-addon-api@^4.2.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
 node-downloader-helper@^2.1.1:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/node-downloader-helper/-/node-downloader-helper-2.1.6.tgz#f73ac458e3ac8c21afd0b952a994eab99c64b879"
@@ -2811,15 +2802,6 @@ node-fetch@^2.6.7:
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.0.tgz#37e71db4ecc257057af828d523a7243d651d91e4"
-  integrity sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==
-  dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
 
 node-gyp@8.x:
   version "8.4.1"
@@ -3602,6 +3584,11 @@ steno@^0.4.1:
   dependencies:
     graceful-fs "^4.1.3"
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -3769,6 +3756,13 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
+undici@^5.0.0:
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.20.0.tgz#6327462f5ce1d3646bcdac99da7317f455bcc263"
+  integrity sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==
+  dependencies:
+    busboy "^1.6.0"
+
 unique-filename@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
@@ -3841,11 +3835,6 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-streams-polyfill@^3.0.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
-  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
-
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -3906,6 +3895,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.12.0:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
 xtend@^4.0.0:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,6 +737,11 @@
     "@aws-sdk/util-buffer-from" "3.208.0"
     tslib "^2.3.1"
 
+"@dqbd/tiktoken@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@dqbd/tiktoken/-/tiktoken-0.4.0.tgz#070e770ae3fa3fa8fccbea4f2e02ab87117f6c3a"
+  integrity sha512-iaHgmwKAOqowBFZKxelyszoeGLoNw62eOULcmyme1aA1Ymr3JgYl0V7jwpuUm7fksalycZajx3loFn9TRUaviw==
+
 "@fastify/ajv-compiler@^3.3.1":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz#459bff00fefbf86c96ec30e62e933d2379e46670"
@@ -937,11 +942,12 @@
     "@types/node" "*"
     "@types/webidl-conversions" "*"
 
-"@waylaidwanderer/chatgpt-api@^1.22.0":
-  version "1.22.5"
-  resolved "https://registry.yarnpkg.com/@waylaidwanderer/chatgpt-api/-/chatgpt-api-1.22.5.tgz#8613c0cd84c1fc4784b49b90dde560ea44231701"
-  integrity sha512-mjuui0ZuBYqpAbpKtpbrP3iYpNBHL5Uj2Rq42jYXBXC5mVTH6GPIUxczrWLFucHYTxau0kupa9SOoeBOZ4d+JQ==
+"@waylaidwanderer/chatgpt-api@^1.23.0":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@waylaidwanderer/chatgpt-api/-/chatgpt-api-1.23.2.tgz#6cd8051d39fdb5a1d11aa8f2cb6a2cd6de31c49c"
+  integrity sha512-JBXwqASFBazp1W7qQKZ0tV88WQ4/xqCX6B4g+XJqMM1QbHSFJ9uEnTbZrUUFFCnOzsmHwDg/UMizl2ISB4dAsw==
   dependencies:
+    "@dqbd/tiktoken" "^0.4.0"
     "@fastify/cors" "^8.2.0"
     "@waylaidwanderer/fastify-sse-v2" "^3.1.0"
     "@waylaidwanderer/fetch-event-source" "^3.0.1"
@@ -950,7 +956,6 @@
     dotenv "^16.0.3"
     fastify "^4.11.0"
     fetch-undici "^3.0.1"
-    gpt-3-encoder "^1.1.4"
     https-proxy-agent "^5.0.1"
     inquirer "^9.1.4"
     inquirer-autocomplete-prompt "^3.0.0"
@@ -2047,11 +2052,6 @@ glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-gpt-3-encoder@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz#d6cdaacf5824857e133b6065247c757fc7e4fa72"
-  integrity sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.6:
   version "4.2.10"


### PR DESCRIPTION
This is kind of a _"dangerous"_ change, as the OpenAI accounts of our users [will be charged](https://platform.openai.com/docs/guides/chat) by simply updating the version to this one.

I'm not sure if we should adjust the readme any further in order to make this clear, so everyone knows the usage is no longer free (and most likely will never become free again at this point).

Also closes #120 and #119 