### PR TITLE
add error code to response

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -127,7 +127,7 @@ export default class CommandHandler {
       const result = await sendChatGPTMessage(this.chatGPT, await bodyWithoutPrefix, storedConversation)
         .catch((error) => {
           LogService.error(`OpenAI-API Error: ${error}`);
-          sendError(this.client, "The bot has encountered an error, please contact your administrator.", roomId, event.event_id);
+          sendError(this.client, `The bot has encountered an error, please contact your administrator (Error code ${error.status || "Unknown"}).`, roomId, event.event_id);
       });
       await Promise.all([
         this.client.setTyping(roomId, false, 500),


### PR DESCRIPTION
as requested in #148, I've added the error code to the response-error text. I did not add another environment variable as I think just the error code should be okay for all users to show.