### PR TITLE
Allow threaded query without prefix, fixes #133

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -81,7 +81,7 @@ export default class CommandHandler {
       if(relatesTo.event_id !== undefined){
         const rootEvent: MessageEvent = await this.client.getEvent(roomId, relatesTo.event_id) // relatesTo is root event.
         const rootPrefixUsed = prefixes.find(p => rootEvent.content.body.startsWith(p));
-        if (!rootPrefixUsed && !(!MATRIX_PREFIX_DM && isDm)) return false;  // Ignore unrelated threads or certain dms
+        if (MATRIX_PREFIX && !rootPrefixUsed && !(!MATRIX_PREFIX_DM && isDm)) return false;  // Ignore unrelated threads or certain dms
       } else { // reply not thread, iterating for a prefix not implemented
         return false;                                                       // Ignore if no relatesTo EventID
       }


### PR DESCRIPTION
Currently, the root message is checked for the presence of prefix when a threaded message is received to filter chatbot invocations. This should be skipped for configurations without a prefix requirement.